### PR TITLE
remove Linq dependency

### DIFF
--- a/src/LZString.cs
+++ b/src/LZString.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Linq;
 
 
 namespace lz_string_csharp
@@ -234,8 +233,9 @@ namespace lz_string_csharp
             string entry = "";
             string result = "";
             int i = 0;
-            dynamic w = "";
-            dynamic c = "";
+            string w = "";
+            string sc = "";
+            int c = 0;
             int errorCount = 0;
 
             data.str = compressed;
@@ -255,22 +255,22 @@ namespace lz_string_csharp
                 switch (next)
                 {
                     case 0:
-                        c = Convert.ToChar(readBits(8, data)).ToString();
+                        sc = Convert.ToChar(readBits(8, data)).ToString();
                         break;
                     case 1:
-                        c = Convert.ToChar(readBits(16, data)).ToString();
+                        sc = Convert.ToChar(readBits(16, data)).ToString();
                         break;
                     case 2:
                         return "";
                 }
 
-                dictionary.Add(c);
-                w = result = c;
+                dictionary.Add(sc);
+                w = result = sc;
 
                 while (true)
                 {
                     c = readBits(numBits, data);
-                    int cc = (int)(c);
+                    int cc = c;
 
                     switch (cc)
                     {
@@ -278,15 +278,15 @@ namespace lz_string_csharp
                             if (errorCount++ > 10000)
                                 throw new Exception("To many errors");
 
-                            c = Convert.ToChar(readBits(8, data)).ToString();
-                            dictionary.Add(c);
+                            sc = Convert.ToChar(readBits(8, data)).ToString();
+                            dictionary.Add(sc);
                             c = dictionary.Count - 1;
                             enlargeIn--;
 
                             break;
                         case 1:
-                            c = Convert.ToChar(readBits(16, data)).ToString();
-                            dictionary.Add(c);
+                            sc = Convert.ToChar(readBits(16, data)).ToString();
+                            dictionary.Add(sc);
                             c = dictionary.Count - 1;
                             enlargeIn--;
 
@@ -302,7 +302,7 @@ namespace lz_string_csharp
                     }
 
 
-                    if (dictionary.ElementAtOrDefault((int)c) != null) // if (dictionary[c] ) <------- original Javascript Equivalant
+                    if (dictionary.Count>c && dictionary[c] != null) // if (dictionary[c] ) <------- original Javascript Equivalant
                     {
                         entry = dictionary[c];
                     }
@@ -531,7 +531,7 @@ namespace lz_string_csharp
             string output = "";
 
             // Using the data type 'double' for these so that the .Net double.NaN & double.IsNaN functions can be used
-            // later in the function.  .Net doesn't have a similar function for regular integers.
+            // later in the function. .Net doesn't have a similar function for regular integers.
             double chr1, chr2, chr3 = 0.0;
 
             int enc1 = 0;
@@ -576,10 +576,10 @@ namespace lz_string_csharp
 
                     enc1 = (int)(Math.Round(chr1)) >> 2;
 
-                    // The next three 'if' statements are there to make sure we are not trying to calculate a value that has been 
-                    // assigned to 'double.NaN' above.  The orginal Javascript functions didn't need these checks due to how
+                    // The next three 'if' statements are there to make sure we are not trying to calculate a value that has been
+                    // assigned to 'double.NaN' above. The orginal Javascript functions didn't need these checks due to how
                     // Javascript functions.
-                    // Also, due to the fact that some of the variables are of the data type 'double', we have to do some type 
+                    // Also, due to the fact that some of the variables are of the data type 'double', we have to do some type
                     // conversion to get the 'enc' variables to be the correct value.
                     if (!double.IsNaN(chr2))
                     {


### PR DESCRIPTION
Removing the Linq dependency enables .net 2.0 dependency thus improves
backward compatibility.
