### PR TITLE
Namespace change, Base64 to Built In, Add URI Components

### DIFF
--- a/lz-string-csharp.sln
+++ b/lz-string-csharp.sln
@@ -1,16 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.9
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "lz-string-csharp", "src\lz-string-csharp.csproj", "{4E440D71-82BE-4217-A1DC-98BF45945EB0}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LZStringCSharp", "src\LZStringCSharp.csproj", "{4E440D71-82BE-4217-A1DC-98BF45945EB0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "lz-string-csharp-tests", "tests\lz-string-csharp-tests.csproj", "{B8504599-355D-46BA-A20B-A4C99369CF6A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LZStringCSharp_Tests", "tests\LZStringCSharp_Tests.csproj", "{B8504599-355D-46BA-A20B-A4C99369CF6A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "files", "files", "{DAC6766A-AB11-4C4F-A077-C6B46AD1CC87}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
+		CONTRIBUTING.md = CONTRIBUTING.md
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/src/LZStringCSharp.csproj
+++ b/src/LZStringCSharp.csproj
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{4E440D71-82BE-4217-A1DC-98BF45945EB0}</ProjectGuid>
     <OutputType>Library</OutputType>
     <NoStandardLibraries>false</NoStandardLibraries>
-    <AssemblyName>LZString</AssemblyName>
+    <AssemblyName>LZStringCSharp</AssemblyName>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
@@ -19,6 +19,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -27,18 +28,15 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <RootNamespace>LZString</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
-    <Reference Include="System.Core" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
@@ -46,7 +44,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="lz-string-csharp.nuspec" />
+    <None Include="LZStringCSharp.nuspec" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSHARP.Targets" />
   <ProjectExtensions>

--- a/src/LZStringCSharp.nuspec
+++ b/src/LZStringCSharp.nuspec
@@ -11,7 +11,7 @@
 		<!--<iconUrl>http://ICON_URL_HERE_OR_DELETE_THIS_LINE</iconUrl>-->
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>LZ String C# Compression Library</description>
-		<releaseNotes>Initial release</releaseNotes>
+		<releaseNotes>Updated Namespace to be less confusing, Changed the Base64 Encode/Decode to use built in C# methods, Added URI Encode/Decode Methods</releaseNotes>
 		<tags>compression lz</tags>
 	</metadata>
 </package>

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -5,11 +5,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("lz-string-csharp")]
+[assembly: AssemblyTitle("LZStringCSharp")]
 [assembly: AssemblyDescription("LZ String C# Compression Library")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("lz-string-csharp")]
+[assembly: AssemblyProduct("LZStringCSharp")]
 [assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/tests/LZStringCSharp_Tests.csproj
+++ b/tests/LZStringCSharp_Tests.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{B8504599-355D-46BA-A20B-A4C99369CF6A}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>lz_string_csharp_tests</RootNamespace>
-    <AssemblyName>lz-string-csharp-tests</AssemblyName>
+    <RootNamespace>LZStringCSharp_Tests</RootNamespace>
+    <AssemblyName>LZStringCSharpTests</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -51,9 +51,9 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\src\lz-string-csharp.csproj">
+    <ProjectReference Include="..\src\LZStringCSharp.csproj">
       <Project>{4E440D71-82BE-4217-A1DC-98BF45945EB0}</Project>
-      <Name>lz-string-csharp</Name>
+      <Name>LZStringCSharp</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/tests/LZStringTests.cs
+++ b/tests/LZStringTests.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
-using lz_string_csharp;
+using LZStringCSharp;
 using NUnit.Framework;
 
-namespace lz_string_csharp_tests
+namespace LZStringCSharp_Tests
 {
     public class LZStringTests
     {
@@ -13,8 +13,9 @@ namespace lz_string_csharp_tests
                 Name = "Json",
                 Uncompressed = "{ \"key\": \"value\" }",
                 Compressed = "㞀⁄ൠꘉ츁렐쀶ղ顀张",
-                CompressedBase64 = "N4AgRA1gpgnmBc4BuBDANgVymEBfIA==",
-                CompressedUTF16 = "ᯠ࠱ǌ઀佐᝘ΐრᬢ峆ࠫ爠"
+                CompressedBase64 = "456A4oGE4LWg6piJ7piF7LiB66CQ7IC21bLpoYDlvKA=",
+                CompressedUTF16 = "ᯠ࠱ǌ઀佐᝘ΐრᬢ峆ࠫ爠",
+                CompressedEncodedURIComponent = "%E3%9E%80%E2%81%84%E0%B5%A0%EA%98%89%EE%98%85%EC%B8%81%EB%A0%90%EC%80%B6%D5%B2%E9%A1%80%E5%BC%A0"
             };
 
             yield return new LZStringTestCase
@@ -22,8 +23,9 @@ namespace lz_string_csharp_tests
                 Name = "UTF-8 String",
                 Uncompressed = "ユニコード",
                 Compressed = "駃⚘操ಃ錌䀀",
-                CompressedBase64 = "mcMmmGTNDIPwyJMMQAA=",
-                CompressedUTF16 = "䴁䧆ಹ僨ᾦ≬ᢠ "
+                CompressedBase64 = "6aeD4pqY5pON4LKD74OI6YyM5ICA",
+                CompressedUTF16 = "䴁䧆ಹ僨ᾦ≬ᢠ ",
+                CompressedEncodedURIComponent = "%E9%A7%83%E2%9A%98%E6%93%8D%E0%B2%83%EF%83%88%E9%8C%8C%E4%80%80"
             };
         }
 
@@ -63,6 +65,12 @@ namespace lz_string_csharp_tests
             Assert.That(LZString.DecompressFromUTF16(test.CompressedUTF16), Is.EqualTo(test.Uncompressed));
         }
 
+        [TestCaseSource(nameof(TestCases))]
+        public void CompressToEncodedURIComponent(LZStringTestCase test)
+        {
+            Assert.That(LZString.CompressToEncodedURIComponent(test.Uncompressed), Is.EqualTo(test.CompressedEncodedURIComponent));
+        }
+
         public struct LZStringTestCase
         {
             public string Name;
@@ -70,6 +78,7 @@ namespace lz_string_csharp_tests
             public string Compressed;
             public string CompressedBase64;
             public string CompressedUTF16;
+            public string CompressedEncodedURIComponent;
             public override string ToString() => Name;
         }
     }

--- a/tests/Properties/AssemblyInfo.cs
+++ b/tests/Properties/AssemblyInfo.cs
@@ -2,11 +2,11 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("lz-string-csharp-tests")]
+[assembly: AssemblyTitle("LZStringCSharpTests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("lz-string-csharp-tests")]
+[assembly: AssemblyProduct("LZStringCSharpTests")]
 [assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]


### PR DESCRIPTION
- Updated Namespace to be less confusing, 
- Changed the Base64 Encode/Decode to use built in C# methods
- Added URI Component Encode/Decode Methods.  This should solve https://github.com/jawa-the-hutt/lz-string-csharp/issues/9