### PR TITLE
add uint8 methods from lzstring js

### DIFF
--- a/src/LZString.cs
+++ b/src/LZString.cs
@@ -74,6 +74,33 @@ namespace LZStringCSharp
             input = input.Replace(" ", "+");
             return Decompress(input.Length, 32, index => KeyStrUriSafeDict[input[index]]);
         }
+        
+        public static byte[] CompressToUint8Array(string uncompressed)
+        {
+            string compressed = Compress(uncompressed);
+            byte[] buf = new byte[compressed.Length * 2];
+
+            for (int i = 0; i < compressed.Length; i++)
+            {
+                int current_value = Convert.ToInt32(compressed[i]);
+                buf[i * 2] = (byte)(current_value >> 8);
+                buf[i * 2 + 1] = (byte)(current_value % 256);
+            }
+            return buf;
+        }
+
+        public static string DecompressFromUint8Array(byte[] compressed)
+        {
+            if (compressed == null) throw new ArgumentNullException(nameof(compressed));
+
+            char[] result = new char[compressed.Length / 2];
+            for (int i = 0; i < result.Length; i++)
+            {
+                result[i] = Convert.ToChar(compressed[i * 2] * 256 + compressed[i * 2 + 1]);
+            }
+
+            return Decompress(new string(result));
+        }
 
         public static string Compress(string uncompressed)
         {

--- a/tests/LZStringTests.cs
+++ b/tests/LZStringTests.cs
@@ -18,7 +18,8 @@ namespace LZStringCSharp.Tests
                 Compressed = "㞀⁄ൠꘉ츁렐쀶ղ顀张",
                 CompressedBase64 = "N4AgRA1gpgnmBc4BuBDANgVymEBfIA==",
                 CompressedUTF16 = "ᯠ࠱ǌ઀佐᝘ΐრᬢ峆ࠫ爠",
-                CompressedEncodedURIComponent = "N4AgRA1gpgnmBc4BuBDANgVymEBfIA"
+                CompressedEncodedURIComponent = "N4AgRA1gpgnmBc4BuBDANgVymEBfIA",
+                CompressedUInt8Array = new byte[] { 55, 128, 32, 68, 13, 96, 166, 9, 230, 5, 206, 1, 184, 16, 192, 54, 5, 114, 152, 64, 95, 32 }
             };
 
             yield return new LZStringTestCase
@@ -28,7 +29,8 @@ namespace LZStringCSharp.Tests
                 Compressed = "駃⚘操ಃ錌䀀",
                 CompressedBase64 = "mcMmmGTNDIPwyJMMQ===",
                 CompressedUTF16 = "䴁䧆ಹ僨ᾦ≬ᢠ",
-                CompressedEncodedURIComponent = "mcMmmGTNDIPwyJMMQ"
+                CompressedEncodedURIComponent = "mcMmmGTNDIPwyJMMQ",
+                CompressedUInt8Array = new byte[] { 153, 195, 38, 152, 100, 205, 12, 131, 240, 200, 147, 12, 64, 0 }
             };
 
             yield return new LZStringTestCase
@@ -38,7 +40,8 @@ namespace LZStringCSharp.Tests
                 Compressed = "̊\0",
                 CompressedBase64 = "Awo=",
                 CompressedUTF16 = "ƥ ",
-                CompressedEncodedURIComponent = "Awo"
+                CompressedEncodedURIComponent = "Awo",
+                CompressedUInt8Array = new byte[] { 3, 10, 0, 0 }
             };
         }
 
@@ -165,6 +168,22 @@ namespace LZStringCSharp.Tests
             Console.WriteLine(compress);
             Assert.That(uncompress, Is.EqualTo(test.Uncompressed));
         }
+        
+        [TestCaseSource(nameof(TestCases))]
+        public void CompatibilityDecompressUInt8ArrayFromNode(LZStringTestCase test)
+        {
+            var compress = test.CompressedUInt8Array;
+            var uncompress = LZString.DecompressFromUint8Array(compress);
+            Assert.That(uncompress, Is.EqualTo(test.Uncompressed));
+        }
+
+        [TestCaseSource(nameof(TestCases))]
+        public void CompatibilityCompressUInt8ArrayFromCSharp(LZStringTestCase test)
+        {
+            var compress = LZString.CompressToUint8Array(test.Uncompressed);
+            var uncompress = test.Uncompressed;
+            Assert.That(uncompress, Is.EqualTo(test.Uncompressed));
+        }
 
         [Test]
         [Explicit]
@@ -211,6 +230,7 @@ namespace LZStringCSharp.Tests
             public string CompressedBase64;
             public string CompressedUTF16;
             public string CompressedEncodedURIComponent;
+            public byte[] CompressedUInt8Array;
             public override string ToString() => Name;
         }
 


### PR DESCRIPTION
replicate uint8 methods from js source to be used in c# as byte arrays